### PR TITLE
matlab backward compatibility & slurm support

### DIFF
--- a/psom_build_dependencies.m
+++ b/psom_build_dependencies.m
@@ -163,6 +163,9 @@ num_in  = num_all(1:length(cell_in));
 num_out = num_all(length(cell_in)+1:length(cell_in)+length(cell_out));
 num_clean = num_all(length(cell_in)+length(cell_out)+1:length(num_all));
 nb_files = max(num_all);
+if isempty(nb_files)
+    nb_files = 0;
+end
 clear num_all val_tmp ind_tmp
 
 %% Build adjacency matrices for jobs x files

--- a/psom_manager.m
+++ b/psom_manager.m
@@ -98,6 +98,9 @@ if ~exist(file_jobs,'file') % Does the pipeline exist ?
     error('Could not find the pipeline file %s. Please use psom_run_pipeline instead of psom_manager directly.',file_jobs);
 end
 
+% pause for ten second in case workers are not ready yet.
+pause(30);
+
 % a try/catch block is used to clean temporary file if the user is
 % interrupting the pipeline of if an error occurs
 try    

--- a/psom_pipeline_init.m
+++ b/psom_pipeline_init.m
@@ -753,7 +753,7 @@ else
 end
 
 path_work = path_search;
-save(file_pipeline,'history','graph_deps','list_jobs','files_in','files_out','path_work')
+save(file_pipeline,'history','graph_deps','list_jobs','files_in','files_out','path_work', '-mat')
 
 %% Save the status
 if flag_verbose>1

--- a/psom_run_script.m
+++ b/psom_run_script.m
@@ -264,7 +264,7 @@ else
         instr_job = sprintf('%sexit\n',instr_job);
     end
 end
-
+instr_job = sprintf('#!/bin/sh\n%s',instr_job);
 %% Write the script
 if ~strcmp(opt.mode,'session')            
     if opt.flag_debug
@@ -404,13 +404,15 @@ switch opt.mode
         % There might be a better way to find the job path and id, 
         % however, I do not know the code well
         % enough at that point.
-        result_path = regexp(script,'(^.*)/logs','tokens'){1}{1};
-        agent_id = regexp(script,'psom_*(\w*)','tokens'){1}{1};
+        result_path = regexp(script,'(^.*)/logs','tokens');
+        result_path = result_path{1}{1};
+        agent_id = regexp(script,'psom_*(\w*)','tokens');
+        agent_id = agent_id{1}{1};
         instr_cbrain = sprintf('%s %s %s', sub, result_path, agent_id);
 
         % Check the max number of worker per node
         % This will start ppn worker per node
-        psom_ppn = getenv("PSOM_WORKER_PPN")
+        psom_ppn = getenv('PSOM_WORKER_PPN')
         if psom_ppn
            file_conf = [result_path '/logs/PIPE_config.mat'];
            pipe_opt = load(file_conf);
@@ -443,8 +445,10 @@ switch opt.mode
         script = [' SPLIT_LINE singularity_exec_options'];
         % There might be a better way to find the job path and id, however, I do not know the code well
         %  enough at that point.
-        result_path = regexp(opt.path_search,'(^.*)/logs','tokens'){1}{1};
-        agent_id = regexp(opt.name_job,'psom_*(\w*)','tokens'){1}{1};
+        result_path = regexp(opt.path_search,'(^.*)/logs','tokens');
+        result_path = result_path{1}{1};
+        agent_id = regexp(opt.name_job,'psom_*(\w*)','tokens');
+        agent_id = agent_id{1}{1};
 
         if ~isempty(logs)
             qsub_logs = [' -e ' logs.eqsub ' -o ' logs.oqsub ' '];
@@ -461,7 +465,7 @@ switch opt.mode
                              , sub, name_job ,qsub_logs, opt.qsub_options ...
                              , script , opt.singularity_image ,result_path, agent_id );
 
-        psom_ppn = getenv("PSOM_WORKER_PPN")
+        psom_ppn = getenv('PSOM_WORKER_PPN')
         if psom_ppn
            file_conf = [result_path '/logs/PIPE_config.mat'];
            pipe_opt = load(file_conf);


### PR DESCRIPTION
# Matlab backward compatibility
Fix the compatibility issue with old age matlab (tested with MATLAB 2012b on Linux, Centos 8):
- old matlab do not accept sparse matrix creation with dimension set to an empty matrix
  ``` matlab   
  sparse([], [], [], 1, []) % this is NOT acceptable
  sparse([], [], [], 1, 0) % this is acceptable
  ```
- only single quote is accetable when defining a string
- matlab does not support subscription on result from a function: `regexp(script,'(^.*)/logs','tokens'){1}{1}` 

# Slurm support
Slurm offers a set of PBS command (qsub, qdel and etc), but it mandatorily require shebang. 

And the solution is simple that to add `#!/bin/sh` to worker script (`$LOG_DIR/tmp/psomX.sh`).